### PR TITLE
feat(backend): polish report reference code logic and add swagger docs

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import express from 'express';
 import cors from 'cors';
+import swaggerUi from 'swagger-ui-express';
 import fs from 'node:fs';
 import admin from 'firebase-admin';
 import { pathToFileURL } from 'node:url';
@@ -13,8 +14,11 @@ const healthRoutesTsPath = path.resolve(__dirname, './src/routes/health.routes.t
 const healthRoutesJsPath = path.resolve(__dirname, './src/routes/health.routes.js');
 const reportsRoutesTsPath = path.resolve(__dirname, './src/routes/reports.routes.ts');
 const reportsRoutesJsPath = path.resolve(__dirname, './src/routes/reports.routes.js');
+const openApiTsPath = path.resolve(__dirname, './src/docs/openapi.ts');
+const openApiJsPath = path.resolve(__dirname, './src/docs/openapi.js');
 const healthRoutesPath = fs.existsSync(healthRoutesTsPath) ? healthRoutesTsPath : healthRoutesJsPath;
 const reportsRoutesPath = fs.existsSync(reportsRoutesTsPath) ? reportsRoutesTsPath : reportsRoutesJsPath;
+const openApiPath = fs.existsSync(openApiTsPath) ? openApiTsPath : openApiJsPath;
 const healthRoutesModule = (await import(pathToFileURL(healthRoutesPath).href)) as {
     createHealthRouter: (db: FirebaseFirestore.Firestore) => express.Router;
 };
@@ -23,6 +27,9 @@ const reportsRoutesModule = (await import(pathToFileURL(reportsRoutesPath).href)
         db: FirebaseFirestore.Firestore,
         bucket: unknown,
     ) => express.Router;
+};
+const openApiModule = (await import(pathToFileURL(openApiPath).href)) as {
+    openApiDocument: object;
 };
 
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
@@ -110,6 +117,7 @@ await runStartupFirestoreCheck();
 
 app.use(cors());
 app.use(express.json());
+app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(openApiModule.openApiDocument));
 
 app.get('/', (req, res) => {
     res.send('Hello World!');

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,13 +14,15 @@
         "express": "^5.2.1",
         "firebase": "^12.8.0",
         "firebase-admin": "^12.7.0",
+        "swagger-ui-express": "^5.0.1",
         "typescript": "^5.9.3",
         "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
-        "@types/node": "^25.2.0"
+        "@types/node": "^25.2.0",
+        "@types/swagger-ui-express": "^4.1.8"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -841,6 +843,13 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -999,6 +1008,17 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -3012,6 +3032,30 @@
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
+      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
     },
     "node_modules/teeny-request": {
       "version": "9.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,12 +17,14 @@
     "express": "^5.2.1",
     "firebase": "^12.8.0",
     "firebase-admin": "^12.7.0",
+    "swagger-ui-express": "^5.0.1",
     "typescript": "^5.9.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
-    "@types/node": "^25.2.0"
+    "@types/node": "^25.2.0",
+    "@types/swagger-ui-express": "^4.1.8"
   }
 }

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -1,0 +1,179 @@
+export const openApiDocument = {
+  openapi: '3.0.3',
+  info: {
+    title: 'FalconsFind Backend API',
+    version: '1.0.0',
+    description: 'API documentation for FalconsFind backend routes.',
+  },
+  servers: [
+    {
+      url: '/',
+      description: 'Current server',
+    },
+  ],
+  tags: [
+    { name: 'Health', description: 'Service and Firebase health checks' },
+    { name: 'Reports', description: 'Lost and found report operations' },
+  ],
+  paths: {
+    '/api/v1/health': {
+      get: {
+        tags: ['Health'],
+        summary: 'Get backend health status',
+        responses: {
+          200: {
+            description: 'Backend is reachable',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/HealthResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/v1/health/firebase': {
+      get: {
+        tags: ['Health'],
+        summary: 'Get Firebase connectivity status',
+        responses: {
+          200: {
+            description: 'Firebase health document was found',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/FirebaseHealthResponse',
+                },
+              },
+            },
+          },
+          404: {
+            description: 'Firebase health document is missing',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse',
+                },
+              },
+            },
+          },
+          500: {
+            description: 'Unexpected Firebase check error',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/v1/reports/lost': {
+      post: {
+        tags: ['Reports'],
+        summary: 'Create a lost-item report',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/CreateLostReportRequest',
+              },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: 'Lost report created successfully',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/CreateLostReportResponse',
+                },
+              },
+            },
+          },
+          400: {
+            description: 'Request validation failed',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse',
+                },
+              },
+            },
+          },
+          500: {
+            description: 'Unexpected server error',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      HealthResponse: {
+        type: 'object',
+        required: ['ok', 'service'],
+        properties: {
+          ok: { type: 'boolean', example: true },
+          service: { type: 'string', example: 'backend' },
+        },
+      },
+      FirebaseHealthResponse: {
+        type: 'object',
+        required: ['ok', 'firebase'],
+        properties: {
+          ok: { type: 'boolean', example: true },
+          firebase: { type: 'boolean', example: true },
+          data: { type: 'object', additionalProperties: true },
+        },
+      },
+      CreateLostReportRequest: {
+        type: 'object',
+        required: ['title'],
+        properties: {
+          title: { type: 'string', minLength: 1 },
+          description: { type: 'string', minLength: 1 },
+          lastSeenLocation: { type: 'string', minLength: 1 },
+          lastSeenAt: { type: 'string', format: 'date-time' },
+          contactEmail: { type: 'string', format: 'email' },
+          photoDataUrl: { type: 'string', description: 'Image encoded as data URL' },
+        },
+      },
+      CreateLostReportResponse: {
+        type: 'object',
+        required: ['id', 'referenceCode'],
+        properties: {
+          id: { type: 'string', example: 'AbCdEF123456' },
+          referenceCode: { type: 'string', example: 'LST-20260214-ABC12345' },
+        },
+      },
+      ErrorResponse: {
+        type: 'object',
+        required: ['error'],
+        properties: {
+          error: {
+            type: 'object',
+            required: ['code', 'message'],
+            properties: {
+              code: { type: 'string', example: 'BAD_REQUEST' },
+              message: { type: 'string', example: 'Invalid request payload' },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;


### PR DESCRIPTION
## Summary
This PR delivers the backend work for US1.3 by polishing reference code generation and documenting all current API routes with Swagger.

## Changes
- Refactored lost report reference code generation to:
  - `LST-YYYYMMDD-XXXXXXXX`
  - Use Firestore generated doc ID for uniqueness/traceability
- Fixed Firestore write payload to avoid optional `undefined` fields (`photoUrl`, etc.)
- Added OpenAPI document and Swagger UI endpoint at:
  - `/api/docs`
- Documented all current backend routes:
  - `GET /api/v1/health`
  - `GET /api/v1/health/firebase`
  - `POST /api/v1/reports/lost`

## Validation
- Backend builds successfully with `npm run build`
- Swagger UI is accessible at `/api/docs`
- Manual API test: `POST /api/v1/reports/lost` returns `201` with:
  - `id`
  - `referenceCode` in expected format (`LST-YYYYMMDD-XXXXXXXX`)

## Notes
- Firebase credentials are required locally via `backend/.env` and are not included in this PR.