### PR TITLE
US1.6: support multiple photos on lost report

### DIFF
--- a/frontend/src/app/features/public-reporting/lost-report-form/lost-report-form.component.html
+++ b/frontend/src/app/features/public-reporting/lost-report-form/lost-report-form.component.html
@@ -144,14 +144,16 @@
           }
 
           @if (currentStep === 3) {
-            <app-lost-report-step-contact
-              [form]="reportForm"
-              [photoPreviewUrl]="photoPreviewUrl"
-              [getFieldError]="getFieldError.bind(this)"
-              [isFieldInvalid]="isFieldInvalid.bind(this)"
-              [onFileSelected]="onFileSelected.bind(this)"
+          <app-lost-report-step-contact
+            [form]="reportForm"
+            [photoPreviewUrls]="photoPreviewUrls"
+            [getFieldError]="getFieldError.bind(this)"
+            [isFieldInvalid]="isFieldInvalid.bind(this)"
+            [onFileSelected]="onFileSelected.bind(this)"
+            [onRemovePhoto]="removePhoto.bind(this)"
             />
           }
+
 
           <div class="flex flex-row justify-end gap-3 pt-6 border-t border-border">
             <app-button 

--- a/frontend/src/app/features/public-reporting/lost-report-form/lost-report-step-contact.component.ts
+++ b/frontend/src/app/features/public-reporting/lost-report-form/lost-report-step-contact.component.ts
@@ -59,73 +59,88 @@ import { TextareaComponent } from '../../../shared/components/forms/textarea.com
     <div class="space-y-4">
       <h3 class="text-lg font-semibold text-text-primary">Additional Information</h3>
 
-      <app-form-field id="photo" label="Photo">
+      <app-form-field id="photos" label="Photos">
         <div
           class="relative border-2 border-dashed border-border rounded-lg bg-bg-secondary hover:border-primary hover:bg-primary/5 transition-all duration-200"
         >
           <input
             type="file"
-            id="photo"
+            id="photos"
+            multiple
             accept="image/jpeg,image/png,image/jpg"
             (change)="onFileSelected($event)"
             class="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-10"
           />
-          @if (form.get('photo')?.value && photoPreviewUrl) {
-            <div class="p-4">
-              <div class="flex items-center gap-2 text-success font-medium text-sm mb-3">
-                <svg
-                  class="w-5 h-5"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.8"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M9 12.75 11.25 15 15 9.75M21 12A9 9 0 1 1 3 12a9 9 0 0 1 18 0Z"
-                  />
-                </svg>
-                Photo uploaded
-              </div>
-              <div class="flex items-center gap-4">
-                <img
-                  [src]="photoPreviewUrl"
-                  alt="Selected photo preview"
-                  class="w-20 h-20 rounded-md object-cover border border-border"
-                />
-                <div class="min-w-0">
-                  <p class="text-sm text-text-primary truncate">{{ form.get('photo')?.value?.name }}</p>
-                  <p class="text-xs text-text-secondary">Click this area to replace image</p>
-                </div>
-              </div>
-            </div>
-          } @else {
-            <div class="text-center py-8">
-              <svg
-                class="w-8 h-8 text-text-secondary mx-auto mb-2"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.8"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M3 16.5V8.25a2.25 2.25 0 0 1 2.25-2.25h2.379a1.5 1.5 0 0 0 1.06-.44l.622-.62a1.5 1.5 0 0 1 1.06-.44h3.258a1.5 1.5 0 0 1 1.06.44l.622.62a1.5 1.5 0 0 0 1.06.44h2.379A2.25 2.25 0 0 1 21 8.25v8.25A2.25 2.25 0 0 1 18.75 18.75H5.25A2.25 2.25 0 0 1 3 16.5Z"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
-                />
-              </svg>
-              <span class="font-medium text-text-primary">Click to upload or drag and drop</span>
-              <span class="text-xs text-text-secondary block mt-1">JPEG, PNG up to 5MB</span>
-            </div>
-          }
+          @if (((form.get('photos')?.value?.length || 0) > 0) && (photoPreviewUrls.length > 0)) {
+  <div class="p-4">
+    <div class="flex items-center justify-between gap-2 mb-3">
+      <div class="flex items-center gap-2 text-success font-medium text-sm">
+        <svg
+          class="w-5 h-5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M9 12.75 11.25 15 15 9.75M21 12A9 9 0 1 1 3 12a9 9 0 0 1 18 0Z"
+          />
+        </svg>
+        {{ form.get('photos')?.value?.length }} photo(s) selected
+      </div>
+      <span class="text-xs text-text-secondary">Click to add more</span>
+    </div>
+
+    <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      @for (url of photoPreviewUrls; track $index) {
+        <div class="relative group">
+          <img
+            [src]="url"
+            alt="Selected photo preview"
+            class="w-full h-24 rounded-md object-cover border border-border"
+          />
+          <button
+            type="button"
+            (click)="onRemovePhoto($index)"
+            class="absolute top-2 right-2 rounded-md bg-bg-primary/90 border border-border px-2 py-1 text-xs text-text-primary opacity-0 group-hover:opacity-100 transition"
+          >
+            Remove
+          </button>
+        </div>
+      }
+    </div>
+
+    <p class="text-xs text-text-secondary mt-3">JPEG, PNG up to 5MB each (max 5)</p>
+  </div>
+} @else {
+  <div class="text-center py-8">
+    <svg
+      class="w-8 h-8 text-text-secondary mx-auto mb-2"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M3 16.5V8.25a2.25 2.25 0 0 1 2.25-2.25h2.379a1.5 1.5 0 0 0 1.06-.44l.622-.62a1.5 1.5 0 0 1 1.06-.44h3.258a1.5 1.5 0 0 1 1.06.44l.622.62a1.5 1.5 0 0 0 1.06.44h2.379A2.25 2.25 0 0 1 21 8.25v8.25A2.25 2.25 0 0 1 18.75 18.75H5.25A2.25 2.25 0 0 1 3 16.5Z"
+      />
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+      />
+    </svg>
+    <span class="font-medium text-text-primary">Click to upload or drag and drop</span>
+    <span class="text-xs text-text-secondary block mt-1">JPEG, PNG up to 5MB each (max 5)</span>
+  </div>
+}
+
         </div>
       </app-form-field>
 
@@ -143,8 +158,9 @@ import { TextareaComponent } from '../../../shared/components/forms/textarea.com
 })
 export class LostReportStepContactComponent {
   @Input({ required: true }) form!: FormGroup;
-  @Input({ required: true }) photoPreviewUrl: string | null = null;
+  @Input({ required: true }) photoPreviewUrls: string[] = [];
   @Input({ required: true }) getFieldError!: (fieldName: string) => string | null;
   @Input({ required: true }) isFieldInvalid!: (fieldName: string) => boolean;
   @Input({ required: true }) onFileSelected!: (event: Event) => void;
+  @Input({ required: true }) onRemovePhoto!: (index: number) => void;
 }


### PR DESCRIPTION
Closes #16
- Updated lost report photo input to allow multiple image uploads
- Added photo preview grid with remove option
- Validates file type/size and caps uploads to 5 photos
