### PR TITLE
refactor: modularize OpenAPI docs by module

### DIFF
--- a/backend/src/docs/modules/health.openapi.ts
+++ b/backend/src/docs/modules/health.openapi.ts
@@ -1,0 +1,114 @@
+import type { OpenApiModule } from '../openapi.types.js';
+
+export const healthOpenApi: OpenApiModule = {
+  tags: [{ name: 'Health', description: 'Service and Firebase health checks' }],
+  paths: {
+    '/health': {
+      get: {
+        tags: ['Health'],
+        summary: 'Get service health status',
+        responses: {
+          200: {
+            description: 'Service is reachable',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/HealthResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/v1/health': {
+      get: {
+        tags: ['Health'],
+        summary: 'Get backend health status',
+        responses: {
+          200: {
+            description: 'Backend is reachable',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/HealthResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/v1/health/firebase': {
+      get: {
+        tags: ['Health'],
+        summary: 'Get Firebase connectivity status',
+        responses: {
+          200: {
+            description: 'Firebase health document was found',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/FirebaseHealthResponse',
+                },
+              },
+            },
+          },
+          404: {
+            description: 'Firebase health document is missing',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse',
+                },
+              },
+            },
+          },
+          500: {
+            description: 'Unexpected Firebase check error',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  schemas: {
+    HealthResponse: {
+      type: 'object',
+      required: ['ok', 'service'],
+      properties: {
+        ok: { type: 'boolean', example: true },
+        service: { type: 'string', example: 'backend' },
+      },
+    },
+    FirebaseHealthResponse: {
+      type: 'object',
+      required: ['ok', 'firebase'],
+      properties: {
+        ok: { type: 'boolean', example: true },
+        firebase: { type: 'boolean', example: true },
+        data: { type: 'object', additionalProperties: true },
+      },
+    },
+    ErrorResponse: {
+      type: 'object',
+      required: ['error'],
+      properties: {
+        error: {
+          type: 'object',
+          required: ['code', 'message'],
+          properties: {
+            code: { type: 'string', example: 'BAD_REQUEST' },
+            message: { type: 'string', example: 'Invalid request payload' },
+          },
+        },
+      },
+    },
+  },
+};

--- a/backend/src/docs/modules/index.ts
+++ b/backend/src/docs/modules/index.ts
@@ -1,0 +1,5 @@
+import type { OpenApiModule } from '../openapi.types.js';
+import { healthOpenApi } from './health.openapi.js';
+import { reportsOpenApi } from './reports.openapi.js';
+
+export const openApiModules: OpenApiModule[] = [healthOpenApi, reportsOpenApi];

--- a/backend/src/docs/modules/reports.openapi.ts
+++ b/backend/src/docs/modules/reports.openapi.ts
@@ -1,0 +1,137 @@
+import type { OpenApiModule } from '../openapi.types.js';
+
+export const reportsOpenApi: OpenApiModule = {
+  tags: [{ name: 'Reports', description: 'Lost and found report operations' }],
+  paths: {
+    '/api/v1/reports/lost': {
+      post: {
+        tags: ['Reports'],
+        summary: 'Create a lost-item report',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/CreateLostReportRequest',
+              },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: 'Lost report created successfully',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/CreateLostReportResponse',
+                },
+              },
+            },
+          },
+          400: {
+            description: 'Request validation failed',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse',
+                },
+              },
+            },
+          },
+          500: {
+            description: 'Unexpected server error',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/v1/reports/found': {
+      post: {
+        tags: ['Reports'],
+        summary: 'Create a found-item report',
+        requestBody: {
+          required: true,
+          content: {
+            'multipart/form-data': {
+              schema: {
+                $ref: '#/components/schemas/CreateFoundReportRequest',
+              },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: 'Found report created successfully',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/CreateLostReportResponse',
+                },
+              },
+            },
+          },
+          400: {
+            description: 'Request validation failed',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse',
+                },
+              },
+            },
+          },
+          500: {
+            description: 'Unexpected server error',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  schemas: {
+    CreateLostReportRequest: {
+      type: 'object',
+      required: ['title'],
+      properties: {
+        title: { type: 'string', minLength: 1 },
+        description: { type: 'string', minLength: 1 },
+        lastSeenLocation: { type: 'string', minLength: 1 },
+        lastSeenAt: { type: 'string', format: 'date-time' },
+        contactEmail: { type: 'string', format: 'email' },
+        photoDataUrl: { type: 'string', description: 'Image encoded as data URL' },
+      },
+    },
+    CreateLostReportResponse: {
+      type: 'object',
+      required: ['id', 'referenceCode'],
+      properties: {
+        id: { type: 'string', example: 'AbCdEF123456' },
+        referenceCode: { type: 'string', example: 'LST-20260214-ABC12345' },
+      },
+    },
+    CreateFoundReportRequest: {
+      type: 'object',
+      required: ['title', 'foundLocation', 'photo'],
+      properties: {
+        title: { type: 'string', minLength: 1 },
+        description: { type: 'string', minLength: 1 },
+        foundLocation: { type: 'string', minLength: 1 },
+        foundAt: { type: 'string', format: 'date-time' },
+        contactEmail: { type: 'string', format: 'email' },
+        photo: { type: 'string', format: 'binary' },
+      },
+    },
+  },
+};

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -1,3 +1,19 @@
+import { openApiModules } from './modules/index.js';
+import type { OpenApiTag } from './openapi.types.js';
+
+const tagsMap = new Map<string, OpenApiTag>();
+const paths: Record<string, Record<string, unknown>> = {};
+const schemas: Record<string, Record<string, unknown>> = {};
+
+for (const moduleDoc of openApiModules) {
+  for (const tag of moduleDoc.tags ?? []) {
+    tagsMap.set(tag.name, tag);
+  }
+
+  Object.assign(paths, moduleDoc.paths ?? {});
+  Object.assign(schemas, moduleDoc.schemas ?? {});
+}
+
 export const openApiDocument = {
   openapi: '3.0.3',
   info: {
@@ -11,247 +27,9 @@ export const openApiDocument = {
       description: 'Current server',
     },
   ],
-  tags: [
-    { name: 'Health', description: 'Service and Firebase health checks' },
-    { name: 'Reports', description: 'Lost and found report operations' },
-  ],
-  paths: {
-    '/health': {
-      get: {
-        tags: ['Health'],
-        summary: 'Get service health status',
-        responses: {
-          200: {
-            description: 'Service is reachable',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/HealthResponse',
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    '/api/v1/health': {
-      get: {
-        tags: ['Health'],
-        summary: 'Get backend health status',
-        responses: {
-          200: {
-            description: 'Backend is reachable',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/HealthResponse',
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    '/api/v1/health/firebase': {
-      get: {
-        tags: ['Health'],
-        summary: 'Get Firebase connectivity status',
-        responses: {
-          200: {
-            description: 'Firebase health document was found',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/FirebaseHealthResponse',
-                },
-              },
-            },
-          },
-          404: {
-            description: 'Firebase health document is missing',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/ErrorResponse',
-                },
-              },
-            },
-          },
-          500: {
-            description: 'Unexpected Firebase check error',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/ErrorResponse',
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    '/api/v1/reports/lost': {
-      post: {
-        tags: ['Reports'],
-        summary: 'Create a lost-item report',
-        requestBody: {
-          required: true,
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/schemas/CreateLostReportRequest',
-              },
-            },
-          },
-        },
-        responses: {
-          201: {
-            description: 'Lost report created successfully',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/CreateLostReportResponse',
-                },
-              },
-            },
-          },
-          400: {
-            description: 'Request validation failed',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/ErrorResponse',
-                },
-              },
-            },
-          },
-          500: {
-            description: 'Unexpected server error',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/ErrorResponse',
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    '/api/v1/reports/found': {
-      post: {
-        tags: ['Reports'],
-        summary: 'Create a found-item report',
-        requestBody: {
-          required: true,
-          content: {
-            'multipart/form-data': {
-              schema: {
-                $ref: '#/components/schemas/CreateFoundReportRequest',
-              },
-            },
-          },
-        },
-        responses: {
-          201: {
-            description: 'Found report created successfully',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/CreateLostReportResponse',
-                },
-              },
-            },
-          },
-          400: {
-            description: 'Request validation failed',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/ErrorResponse',
-                },
-              },
-            },
-          },
-          500: {
-            description: 'Unexpected server error',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/ErrorResponse',
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  },
+  tags: Array.from(tagsMap.values()),
+  paths,
   components: {
-    schemas: {
-      HealthResponse: {
-        type: 'object',
-        required: ['ok', 'service'],
-        properties: {
-          ok: { type: 'boolean', example: true },
-          service: { type: 'string', example: 'backend' },
-        },
-      },
-      FirebaseHealthResponse: {
-        type: 'object',
-        required: ['ok', 'firebase'],
-        properties: {
-          ok: { type: 'boolean', example: true },
-          firebase: { type: 'boolean', example: true },
-          data: { type: 'object', additionalProperties: true },
-        },
-      },
-      CreateLostReportRequest: {
-        type: 'object',
-        required: ['title'],
-        properties: {
-          title: { type: 'string', minLength: 1 },
-          description: { type: 'string', minLength: 1 },
-          lastSeenLocation: { type: 'string', minLength: 1 },
-          lastSeenAt: { type: 'string', format: 'date-time' },
-          contactEmail: { type: 'string', format: 'email' },
-          photoDataUrl: { type: 'string', description: 'Image encoded as data URL' },
-        },
-      },
-      CreateLostReportResponse: {
-        type: 'object',
-        required: ['id', 'referenceCode'],
-        properties: {
-          id: { type: 'string', example: 'AbCdEF123456' },
-          referenceCode: { type: 'string', example: 'LST-20260214-ABC12345' },
-        },
-      },
-      CreateFoundReportRequest: {
-        type: 'object',
-        required: ['title', 'foundLocation', 'photo'],
-        properties: {
-          title: { type: 'string', minLength: 1 },
-          description: { type: 'string', minLength: 1 },
-          foundLocation: { type: 'string', minLength: 1 },
-          foundAt: { type: 'string', format: 'date-time' },
-          contactEmail: { type: 'string', format: 'email' },
-          photo: { type: 'string', format: 'binary' },
-        },
-      },
-      ErrorResponse: {
-        type: 'object',
-        required: ['error'],
-        properties: {
-          error: {
-            type: 'object',
-            required: ['code', 'message'],
-            properties: {
-              code: { type: 'string', example: 'BAD_REQUEST' },
-              message: { type: 'string', example: 'Invalid request payload' },
-            },
-          },
-        },
-      },
-    },
+    schemas,
   },
 } as const;

--- a/backend/src/docs/openapi.types.ts
+++ b/backend/src/docs/openapi.types.ts
@@ -1,0 +1,13 @@
+export type OpenApiTag = {
+  name: string;
+  description?: string;
+};
+
+export type OpenApiSchema = Record<string, unknown>;
+export type OpenApiPathItem = Record<string, unknown>;
+
+export type OpenApiModule = {
+  tags?: OpenApiTag[];
+  paths?: Record<string, OpenApiPathItem>;
+  schemas?: Record<string, OpenApiSchema>;
+};


### PR DESCRIPTION
**Summary:**
This PR refactors the Swagger/OpenAPI setup into a modular structure organized by route domain.

**What changed:**

- Split Health documentation into its own OpenAPI module
- Split Reports documentation into its own OpenAPI module
- Added a module aggregator to compose all documentation modules
- Added shared OpenAPI types for consistency
- Simplified the main OpenAPI document file to only assemble tags, paths, and schemas from modules

**Why:**

- Avoid a single monolithic documentation file
- Improve maintainability and scalability as routes grow
- Make it easier to add new route documentation per module

**Validation:**

- Ran lint successfully
- Ran build successfully
- Confirmed health endpoint responds with 200
- Confirmed Swagger UI is still working and shows Health and Reports routes