### PR TITLE
US3.2 add claim review page with approve/reject UI (hardcoded data) 

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { LostReportFormComponent } from './features/public-reporting/lost-report
 import { FoundItemsPageComponent } from './features/items/pages/found-items-page/found-items-page';
 import { ItemDetailsComponent } from './features/items/item-details/item-details.component';
 import { ClaimRequest } from './claim-request/claim-request';
+import { ClaimReview } from './claim-review/claim-review';
 
 export const routes: Routes = [
   {
@@ -31,6 +32,11 @@ export const routes: Routes = [
   path: 'claim-request',
   component: ClaimRequest
 },
+  {
+    path: 'admin/claims',
+    component: ClaimReview,
+    title: 'Claim Review - FalconFind'
+  },
   {
     path: 'items/:id',
     component: ItemDetailsComponent,

--- a/frontend/src/app/claim-review/claim-review.css
+++ b/frontend/src/app/claim-review/claim-review.css
@@ -1,0 +1,148 @@
+.review-page {
+  min-height: 100vh;
+  background: var(--color-neutral-base);
+  padding: var(--space-xl) var(--space-md);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.review-card {
+  width: 100%;
+  max-width: 900px;
+  background: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-xl);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+}
+
+.review-card h1 {
+  color: var(--color-primary);
+  margin-bottom: var(--space-sm);
+}
+
+.intro-text {
+  margin-bottom: var(--space-lg);
+  color: var(--color-text-secondary);
+}
+
+.claims-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.claim-item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  background: var(--color-bg-secondary);
+}
+
+.claim-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.claim-header h2 {
+  margin: 0;
+  color: var(--color-text-primary);
+}
+
+.status-badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.status-badge.pending {
+  background: color-mix(in srgb, var(--color-warning) 20%, white);
+  color: #8a6500;
+}
+
+.status-badge.approved {
+  background: color-mix(in srgb, var(--color-success) 18%, white);
+  color: var(--color-success);
+}
+
+.status-badge.rejected {
+  background: color-mix(in srgb, var(--color-error) 15%, white);
+  color: var(--color-error);
+}
+
+.claim-item p {
+  margin-bottom: var(--space-sm);
+}
+
+.button-group {
+  display: flex;
+  gap: var(--space-md);
+  margin-top: var(--space-md);
+}
+
+button {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 12px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.approve-btn {
+  background: var(--color-success);
+  color: var(--color-white);
+}
+
+.approve-btn:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.reject-btn {
+  background: var(--color-error);
+  color: var(--color-white);
+}
+
+.reject-btn:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.message {
+  margin-bottom: var(--space-md);
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  font-weight: 500;
+}
+
+.success-message {
+  background: color-mix(in srgb, var(--color-success) 15%, white);
+  color: var(--color-success);
+  border: 1px solid color-mix(in srgb, var(--color-success) 35%, white);
+}
+
+.error-message {
+  background: color-mix(in srgb, var(--color-error) 12%, white);
+  color: var(--color-error);
+  border: 1px solid color-mix(in srgb, var(--color-error) 30%, white);
+}
+
+@media (max-width: 768px) {
+  .claim-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .button-group {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/app/claim-review/claim-review.html
+++ b/frontend/src/app/claim-review/claim-review.html
@@ -1,0 +1,63 @@
+<div class="review-page">
+  <div class="review-card">
+    <h1>Claim Requests</h1>
+    <p class="intro-text">
+      Review submitted claim requests and approve or reject them.
+    </p>
+
+    @if (successMessage) {
+      <div class="message success-message">
+        {{ successMessage }}
+      </div>
+    }
+
+    @if (errorMessage) {
+      <div class="message error-message">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="claims-list">
+      @for (claim of claims; track claim.id) {
+        <div class="claim-item">
+          <div class="claim-header">
+            <h2>{{ claim.itemName }}</h2>
+            <span
+              class="status-badge"
+              [class.pending]="claim.status === 'Pending'"
+              [class.approved]="claim.status === 'Approved'"
+              [class.rejected]="claim.status === 'Rejected'"
+            >
+              {{ claim.status }}
+            </span>
+          </div>
+
+          <p><strong>Claim ID:</strong> {{ claim.id }}</p>
+          <p><strong>Full Name:</strong> {{ claim.fullName }}</p>
+          <p><strong>Email:</strong> {{ claim.email }}</p>
+          <p><strong>Reference Code:</strong> {{ claim.referenceCode }}</p>
+          <p><strong>Claim Reason:</strong> {{ claim.claimReason }}</p>
+          <p><strong>Proof Details:</strong> {{ claim.proofDetails }}</p>
+
+          <div class="button-group">
+            <button
+              class="approve-btn"
+              (click)="approveClaim(claim)"
+              [disabled]="claim.status !== 'Pending'"
+            >
+              Approve
+            </button>
+
+            <button
+              class="reject-btn"
+              (click)="rejectClaim(claim)"
+              [disabled]="claim.status !== 'Pending'"
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/claim-review/claim-review.spec.ts
+++ b/frontend/src/app/claim-review/claim-review.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClaimReview } from './claim-review';
+
+describe('ClaimReview', () => {
+  let component: ClaimReview;
+  let fixture: ComponentFixture<ClaimReview>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ClaimReview]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ClaimReview);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/claim-review/claim-review.ts
+++ b/frontend/src/app/claim-review/claim-review.ts
@@ -1,0 +1,74 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface ClaimRequestItem {
+  id: string;
+  fullName: string;
+  email: string;
+  referenceCode: string;
+  itemName: string;
+  claimReason: string;
+  proofDetails: string;
+  status: 'Pending' | 'Approved' | 'Rejected';
+}
+
+@Component({
+  selector: 'app-claim-review',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './claim-review.html',
+  styleUrl: './claim-review.css'
+})
+export class ClaimReview {
+  successMessage = '';
+  errorMessage = '';
+
+  claims: ClaimRequestItem[] = [
+    {
+      id: 'CLM-001',
+      fullName: 'Maria Brown',
+      email: 'maria@email.com',
+      referenceCode: 'FF-1024',
+      itemName: 'Black Backpack',
+      claimReason: 'I lost it in the library on Tuesday.',
+      proofDetails: 'It has a silver water bottle in the side pocket and a Dell laptop inside.',
+      status: 'Pending'
+    },
+    {
+      id: 'CLM-002',
+      fullName: 'John Smith',
+      email: 'john@email.com',
+      referenceCode: 'FF-2048',
+      itemName: 'Blue Jacket',
+      claimReason: 'I left it in the cafeteria.',
+      proofDetails: 'There is a bus pass in the inside pocket.',
+      status: 'Pending'
+    }
+  ];
+
+  approveClaim(claim: ClaimRequestItem) {
+    this.successMessage = '';
+    this.errorMessage = '';
+
+    try {
+      claim.status = 'Approved';
+      this.successMessage = `Claim ${claim.id} was approved successfully.`;
+    } catch (error) {
+      this.errorMessage = 'There was an error approving the claim.';
+      console.error(error);
+    }
+  }
+
+  rejectClaim(claim: ClaimRequestItem) {
+    this.successMessage = '';
+    this.errorMessage = '';
+
+    try {
+      claim.status = 'Rejected';
+      this.successMessage = `Claim ${claim.id} was rejected successfully.`;
+    } catch (error) {
+      this.errorMessage = 'There was an error rejecting the claim.';
+      console.error(error);
+    }
+  }
+}


### PR DESCRIPTION
Implements frontend UI for US3.2 – Approve/Reject Claim Requests.

Features:
• Claim review page
• Approve and reject buttons
• Status updates
• Styled with project design tokens

NOTE:
The claim data is currently hardcoded for UI testing.
Once the backend API for claims is available, this component will be updated to fetch real claim data.