### PR TITLE
US3.4 add cancel claim request page (UI only)

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { FoundItemsPageComponent } from './features/items/pages/found-items-page
 import { ItemDetailsComponent } from './features/items/item-details/item-details.component';
 import { ClaimRequest } from './claim-request/claim-request';
 import { ClaimReview } from './claim-review/claim-review';
+import { ClaimCancel } from './claim-cancel/claim-cancel';
 
 export const routes: Routes = [
   {
@@ -36,6 +37,11 @@ export const routes: Routes = [
     path: 'admin/claims',
     component: ClaimReview,
     title: 'Claim Review - FalconFind'
+  },
+    {
+    path: 'claim-cancel',
+    component: ClaimCancel,
+    title: 'Cancel Claim Request - FalconFind'
   },
   {
     path: 'items/:id',

--- a/frontend/src/app/claim-cancel/claim-cancel.css
+++ b/frontend/src/app/claim-cancel/claim-cancel.css
@@ -1,0 +1,139 @@
+.cancel-page {
+  min-height: 100vh;
+  background: var(--color-neutral-base);
+  padding: var(--space-xl) var(--space-md);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.cancel-card {
+  width: 100%;
+  max-width: 720px;
+  background: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-xl);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+}
+
+.cancel-card h1 {
+  color: var(--color-primary);
+  margin-bottom: var(--space-sm);
+}
+
+.intro-text {
+  margin-bottom: var(--space-lg);
+  color: var(--color-text-secondary);
+}
+
+.claim-summary {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  margin-bottom: var(--space-lg);
+}
+
+.claim-summary h2 {
+  margin-bottom: var(--space-md);
+  color: var(--color-text-primary);
+}
+
+.claim-summary p {
+  margin-bottom: var(--space-sm);
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.status-badge.pending {
+  background: color-mix(in srgb, var(--color-warning) 20%, white);
+  color: #8a6500;
+}
+
+.status-badge.cancelled {
+  background: color-mix(in srgb, var(--color-error) 15%, white);
+  color: var(--color-error);
+}
+
+.cancel-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.cancel-section label {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.cancel-section input {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-white);
+  color: var(--color-text-primary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cancel-section input::placeholder {
+  color: var(--color-text-secondary);
+}
+
+.cancel-section input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
+}
+
+button {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 14px 18px;
+  background: var(--color-error);
+  color: var(--color-white);
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+button:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.message {
+  margin-bottom: var(--space-md);
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  font-weight: 500;
+}
+
+.success-message {
+  background: color-mix(in srgb, var(--color-success) 15%, white);
+  color: var(--color-success);
+  border: 1px solid color-mix(in srgb, var(--color-success) 35%, white);
+}
+
+.error-message {
+  background: color-mix(in srgb, var(--color-error) 12%, white);
+  color: var(--color-error);
+  border: 1px solid color-mix(in srgb, var(--color-error) 30%, white);
+}
+
+@media (max-width: 768px) {
+  .cancel-card {
+    padding: var(--space-lg);
+  }
+}

--- a/frontend/src/app/claim-cancel/claim-cancel.html
+++ b/frontend/src/app/claim-cancel/claim-cancel.html
@@ -1,0 +1,60 @@
+<div class="cancel-page">
+  <div class="cancel-card">
+    <h1>Cancel Claim Request</h1>
+    <p class="intro-text">
+      If you no longer want to proceed with your claim request, you can cancel it here.
+    </p>
+
+    @if (successMessage) {
+      <div class="message success-message">
+        {{ successMessage }}
+      </div>
+    }
+
+    @if (errorMessage) {
+      <div class="message error-message">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="claim-summary">
+      <h2>Claim Details</h2>
+      <p><strong>Claim ID:</strong> {{ claim.claimId }}</p>
+      <p><strong>Full Name:</strong> {{ claim.fullName }}</p>
+      <p><strong>Item Name:</strong> {{ claim.itemName }}</p>
+      <p><strong>Reference Code:</strong> {{ claim.referenceCode }}</p>
+      <p>
+        <strong>Status:</strong>
+        <span
+          class="status-badge"
+          [class.pending]="claim.status === 'Pending'"
+          [class.cancelled]="claim.status === 'Cancelled'"
+        >
+          {{ claim.status }}
+        </span>
+      </p>
+    </div>
+
+    <div class="cancel-section">
+      <label for="confirmationText">
+        Type <strong>CANCEL</strong> to confirm cancellation
+      </label>
+      <input
+        type="text"
+        id="confirmationText"
+        name="confirmationText"
+        [(ngModel)]="confirmationText"
+        placeholder="Type CANCEL"
+        [disabled]="claim.status === 'Cancelled'"
+      />
+
+      <button
+        type="button"
+        (click)="cancelClaim()"
+        [disabled]="isCancelling || claim.status === 'Cancelled'"
+      >
+        {{ isCancelling ? 'Cancelling...' : 'Cancel Claim Request' }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/claim-cancel/claim-cancel.spec.ts
+++ b/frontend/src/app/claim-cancel/claim-cancel.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClaimCancel } from './claim-cancel';
+
+describe('ClaimCancel', () => {
+  let component: ClaimCancel;
+  let fixture: ComponentFixture<ClaimCancel>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ClaimCancel]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ClaimCancel);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/claim-cancel/claim-cancel.ts
+++ b/frontend/src/app/claim-cancel/claim-cancel.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-claim-cancel',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './claim-cancel.html',
+  styleUrl: './claim-cancel.css'
+})
+export class ClaimCancel {
+  claim = {
+    claimId: 'CLM-001',
+    fullName: 'Maria Brown',
+    itemName: 'Black Backpack',
+    referenceCode: 'FF-1024',
+    status: 'Pending'
+  };
+
+  confirmationText = '';
+  successMessage = '';
+  errorMessage = '';
+  isCancelling = false;
+
+  cancelClaim() {
+    this.successMessage = '';
+    this.errorMessage = '';
+
+    if (this.claim.status !== 'Pending') {
+      this.errorMessage = 'Only pending claim requests can be cancelled.';
+      return;
+    }
+
+    if (this.confirmationText.trim().toUpperCase() !== 'CANCEL') {
+      this.errorMessage = 'Please type CANCEL to confirm.';
+      return;
+    }
+
+    this.isCancelling = true;
+
+    try {
+      this.claim.status = 'Cancelled';
+      this.successMessage = `Claim ${this.claim.claimId} has been cancelled successfully.`;
+      this.confirmationText = '';
+    } catch (error) {
+      this.errorMessage = 'There was an error cancelling the claim request.';
+      console.error(error);
+    } finally {
+      this.isCancelling = false;
+    }
+  }
+}


### PR DESCRIPTION
Implements frontend UI for US3.4 – Cancel Claim Request.

Features:
• Claim summary display
• Confirmation input for cancellation
• Cancel claim button
• Success and error feedback
• Styled with project design tokens

NOTE:
The claim data is currently hardcoded for UI testing.
Once the backend API for claims is available, this component will be updated to cancel real claim data.