### PR TITLE
US4.3 implement centralized admin dashboard with filters and stats

### DIFF
--- a/frontend/src/app/features/admin/admin-dashboard.component.html
+++ b/frontend/src/app/features/admin/admin-dashboard.component.html
@@ -1,49 +1,146 @@
-<section class="p-6">
-  <h1 class="text-3xl font-semibold text-text-primary mb-3">Admin Dashboard</h1>
-  <p class="text-text-secondary mb-6">
-    Review reported found items before they are published.
-  </p>
+<section class="admin-dashboard">
+  <div class="dashboard-header">
+    <div>
+      <h1>Admin Dashboard</h1>
+      <p>View and manage all lost and found reports in one place.</p>
+    </div>
+  </div>
+
+  <div class="stats-grid">
+    <div class="stat-card">
+      <span class="stat-label">Total Reports</span>
+      <span class="stat-value">{{ totalReports }}</span>
+    </div>
+
+    <div class="stat-card">
+      <span class="stat-label">Pending</span>
+      <span class="stat-value">{{ pendingCount }}</span>
+    </div>
+
+    <div class="stat-card">
+      <span class="stat-label">Approved</span>
+      <span class="stat-value">{{ approvedCount }}</span>
+    </div>
+
+    <div class="stat-card">
+      <span class="stat-label">Rejected</span>
+      <span class="stat-value">{{ rejectedCount }}</span>
+    </div>
+  </div>
+
+  <div class="filters-bar">
+    <div class="filter-group">
+      <label for="search">Search reports</label>
+      <input
+        #searchInput
+        id="search"
+        type="text"
+        placeholder="Search by item, description, category, location, or status"
+        (input)="onSearchChange(searchInput.value)"
+      />
+    </div>
+
+    <div class="filter-group">
+      <label for="statusFilter">Filter by status</label>
+      <select
+        #statusSelect
+        id="statusFilter"
+        (change)="onStatusFilterChange(statusSelect.value)"
+      >
+        <option value="all">All</option>
+        <option value="pending">Pending</option>
+        <option value="approved">Approved</option>
+        <option value="rejected">Rejected</option>
+        <option value="claimed">Claimed</option>
+        <option value="returned">Returned</option>
+      </select>
+    </div>
+  </div>
 
   @if (loading) {
-    <p>Loading pending items...</p>
+    <p class="status-message">Loading reports...</p>
   }
 
   @if (error) {
-    <p class="text-red-600 font-medium">{{ error }}</p>
+    <p class="error-message">{{ error }}</p>
   }
 
-  @if (!loading && !error && pendingItems.length === 0) {
-    <p>No pending found items to review.</p>
+  @if (!loading && !error && filteredItems.length === 0) {
+    <p class="status-message">No reports found for the current filters.</p>
   }
 
-  @for (item of pendingItems; track item._id) {
-    <div class="border rounded-lg p-4 mb-4 bg-white shadow-sm">
-      <h2 class="text-xl font-semibold mb-2">
-        {{ item.itemName || item.title || 'Untitled Item' }}
-      </h2>
+  @if (!loading && !error && filteredItems.length > 0) {
+    <div class="reports-table-wrapper">
+      <table class="reports-table">
+        <thead>
+          <tr>
+            <th>Item</th>
+            <th>Category</th>
+            <th>Location</th>
+            <th>Date Found</th>
+            <th>Status</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
 
-      <p class="mb-1"><strong>Description:</strong> {{ item.description || 'No description provided.' }}</p>
-      <p class="mb-1"><strong>Category:</strong> {{ item.category || 'N/A' }}</p>
-      <p class="mb-1"><strong>Location:</strong> {{ item.locationFound || item.location || 'N/A' }}</p>
-      <p class="mb-3"><strong>Date:</strong> {{ item.dateFound || 'N/A' }}</p>
+        <tbody>
+          @for (item of filteredItems; track trackByItemId($index, item)) {
+            <tr>
+              <td>
+                <div class="item-name">
+                  {{ item.itemName || item.title || 'Untitled Item' }}
+                </div>
+                <div class="item-description">
+                  {{ item.description || 'No description provided.' }}
+                </div>
+              </td>
 
-      <div class="flex gap-3">
-        <button
-          type="button"
-          (click)="approveItem(item._id)"
-          class="rounded-lg px-4 py-2 bg-green-600 text-white hover:bg-green-700 transition-colors"
-        >
-          Approve
-        </button>
+              <td>{{ item.category || 'N/A' }}</td>
+              <td>{{ item.locationFound || item.location || 'N/A' }}</td>
+              <td>{{ item.dateFound || 'N/A' }}</td>
 
-        <button
-          type="button"
-          (click)="rejectItem(item._id)"
-          class="rounded-lg px-4 py-2 bg-red-600 text-white hover:bg-red-700 transition-colors"
-        >
-          Reject
-        </button>
-      </div>
+              <td>
+                <span
+                  class="status-badge"
+                  [ngClass]="{
+                    'pending': item.status === 'pending',
+                    'approved': item.status === 'approved',
+                    'rejected': item.status === 'rejected',
+                    'claimed': item.status === 'claimed',
+                    'returned': item.status === 'returned'
+                  }"
+                >
+                  {{ formatStatus(item.status) }}
+                </span>
+              </td>
+
+              <td>
+                @if (item.status === 'pending') {
+                  <div class="actions">
+                    <button
+                      type="button"
+                      class="approve-btn"
+                      (click)="approveItem(item._id)"
+                    >
+                      Approve
+                    </button>
+
+                    <button
+                      type="button"
+                      class="reject-btn"
+                      (click)="rejectItem(item._id)"
+                    >
+                      Reject
+                    </button>
+                  </div>
+                } @else {
+                  <span class="no-actions">No actions</span>
+                }
+              </td>
+            </tr>
+          }
+        </tbody>
+      </table>
     </div>
   }
 </section>

--- a/frontend/src/app/features/admin/admin-dashboard.component.scss
+++ b/frontend/src/app/features/admin/admin-dashboard.component.scss
@@ -2,6 +2,87 @@
   padding: 24px;
 }
 
+.dashboard-header {
+  margin-bottom: 24px;
+
+  h1 {
+    margin: 0 0 8px;
+    font-size: 2rem;
+    font-weight: 700;
+    color: #1f2937;
+  }
+
+  p {
+    margin: 0;
+    color: #6b7280;
+  }
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.stat-card {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 18px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+
+  .stat-label {
+    display: block;
+    font-size: 0.9rem;
+    color: #6b7280;
+    margin-bottom: 8px;
+  }
+
+  .stat-value {
+    display: block;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #111827;
+  }
+}
+
+.filters-bar {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+  align-items: end;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 260px;
+
+  label {
+    font-weight: 600;
+    color: #374151;
+  }
+
+  input,
+  select {
+    padding: 10px 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    background: #ffffff;
+  }
+
+  input:focus,
+  select:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+  }
+}
+
 .status-message {
   margin: 16px 0;
   color: #444;
@@ -13,28 +94,133 @@
   font-weight: 600;
 }
 
-.item-card {
-  border: 1px solid #ddd;
-  border-radius: 10px;
-  padding: 16px;
-  margin-bottom: 16px;
-  background: #fff;
+.reports-table-wrapper {
+  overflow-x: auto;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
 }
 
-.item-card h2 {
-  margin-top: 0;
-  margin-bottom: 12px;
+.reports-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 14px 16px;
+    text-align: left;
+    border-bottom: 1px solid #e5e7eb;
+    vertical-align: top;
+  }
+
+  th {
+    background: #f9fafb;
+    font-size: 0.9rem;
+    color: #374151;
+    font-weight: 700;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.item-name {
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 6px;
+}
+
+.item-description {
+  color: #6b7280;
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.status-badge.pending {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.status-badge.approved {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-badge.rejected {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.status-badge.claimed {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.status-badge.returned {
+  background: #ede9fe;
+  color: #6d28d9;
 }
 
 .actions {
   display: flex;
-  gap: 12px;
-  margin-top: 16px;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .actions button {
   padding: 8px 14px;
   border: none;
-  border-radius: 6px;
+  border-radius: 8px;
   cursor: pointer;
+  font-weight: 600;
+}
+
+.approve-btn {
+  background: #16a34a;
+  color: #ffffff;
+}
+
+.approve-btn:hover {
+  background: #15803d;
+}
+
+.reject-btn {
+  background: #dc2626;
+  color: #ffffff;
+}
+
+.reject-btn:hover {
+  background: #b91c1c;
+}
+
+.no-actions {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 900px) {
+  .stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-dashboard {
+    padding: 16px;
+  }
 }

--- a/frontend/src/app/features/admin/admin-dashboard.component.ts
+++ b/frontend/src/app/features/admin/admin-dashboard.component.ts
@@ -2,14 +2,36 @@ import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
-type PendingItemsResponse = {
+type ReportStatus =
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'claimed'
+  | 'returned'
+  | string;
+
+type FoundItem = {
+  _id: string;
+  itemName?: string;
+  title?: string;
+  description?: string;
+  category?: string;
+  locationFound?: string;
+  location?: string;
+  dateFound?: string;
+  status?: ReportStatus;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type ItemsResponse = {
   page: number;
   limit: number;
   total: number;
   totalPages: number;
   hasNextPage: boolean;
   hasPrevPage: boolean;
-  items: any[];
+  items: FoundItem[];
 };
 
 @Component({
@@ -20,9 +42,19 @@ type PendingItemsResponse = {
   styleUrls: ['./admin-dashboard.component.scss']
 })
 export class AdminDashboardComponent implements OnInit {
-  pendingItems: any[] = [];
+  allItems: FoundItem[] = [];
+  filteredItems: FoundItem[] = [];
+
   loading = false;
   error = '';
+
+  searchTerm = '';
+  selectedStatus = 'all';
+
+  totalReports = 0;
+  pendingCount = 0;
+  approvedCount = 0;
+  rejectedCount = 0;
 
   constructor(
     private http: HttpClient,
@@ -31,28 +63,78 @@ export class AdminDashboardComponent implements OnInit {
 
   ngOnInit(): void {
     if (isPlatformBrowser(this.platformId)) {
-      this.loadPendingItems();
+      this.loadAllReports();
     } else {
       this.loading = false;
     }
   }
 
-  loadPendingItems(): void {
+  loadAllReports(): void {
     this.loading = true;
     this.error = '';
 
-    this.http.get<PendingItemsResponse>('/items?status=pending&page=1&limit=50').subscribe({
+    this.http.get<ItemsResponse>('/items?page=1&limit=100').subscribe({
       next: (response) => {
-        console.log('Pending items response:', response);
-        this.pendingItems = response.items ?? [];
+        this.allItems = (response.items ?? []).map((item) => ({
+          ...item,
+          status: (item.status || 'pending').toLowerCase()
+        }));
+
+        this.totalReports = this.allItems.length;
+        this.pendingCount = this.allItems.filter(
+          (item) => item.status === 'pending'
+        ).length;
+        this.approvedCount = this.allItems.filter(
+          (item) => item.status === 'approved'
+        ).length;
+        this.rejectedCount = this.allItems.filter(
+          (item) => item.status === 'rejected'
+        ).length;
+
+        this.applyFilters();
         this.loading = false;
       },
       error: (err) => {
-        console.error('Failed to load pending items:', err);
-        this.error = 'Failed to load pending found items.';
+        console.error('Failed to load reports:', err);
+        this.error = 'Failed to load reports.';
         this.loading = false;
       }
     });
+  }
+
+  applyFilters(): void {
+    const search = this.searchTerm.trim().toLowerCase();
+
+    this.filteredItems = this.allItems.filter((item) => {
+      const itemName = (item.itemName || item.title || '').toLowerCase();
+      const description = (item.description || '').toLowerCase();
+      const category = (item.category || '').toLowerCase();
+      const location = (item.locationFound || item.location || '').toLowerCase();
+      const status = (item.status || '').toLowerCase();
+
+      const matchesSearch =
+        !search ||
+        itemName.includes(search) ||
+        description.includes(search) ||
+        category.includes(search) ||
+        location.includes(search) ||
+        status.includes(search);
+
+      const matchesStatus =
+        this.selectedStatus === 'all' || status === this.selectedStatus;
+
+      return matchesSearch && matchesStatus;
+    });
+  }
+
+  onSearchChange(value: string): void {
+    this.searchTerm = value;
+    this.applyFilters();
+  }
+
+  onStatusFilterChange(value: string): void {
+    this.selectedStatus = value;
+    this.applyFilters();
   }
 
   approveItem(itemId: string): void {
@@ -60,7 +142,7 @@ export class AdminDashboardComponent implements OnInit {
       status: 'approved'
     }).subscribe({
       next: () => {
-        this.loadPendingItems();
+        this.loadAllReports();
       },
       error: (err) => {
         console.error('Failed to approve item:', err);
@@ -74,12 +156,21 @@ export class AdminDashboardComponent implements OnInit {
       status: 'rejected'
     }).subscribe({
       next: () => {
-        this.loadPendingItems();
+        this.loadAllReports();
       },
       error: (err) => {
         console.error('Failed to reject item:', err);
         this.error = 'Failed to reject item.';
       }
     });
+  }
+
+  formatStatus(status?: string): string {
+    if (!status) return 'Unknown';
+    return status.charAt(0).toUpperCase() + status.slice(1);
+  }
+
+  trackByItemId(index: number, item: FoundItem): string {
+    return item._id;
   }
 }


### PR DESCRIPTION
Implemented the centralized admin dashboard for viewing and managing all reports.
Changes:
- Added summary cards (total, pending, approved, rejected)
- Added search functionality across reports
- Added status filtering
- Displayed all reports in a structured table
- Enabled approve/reject actions for pending reports
- Ensured browser-only data loading to avoid SSR/prerender deployment issues

Note:
Backend integration is required for the /items endpoint. The UI and filtering logic are complete and will display data once the backend is connected.