### PR TITLE
fix: add category to found report form

### DIFF
--- a/backend/test/integration/reports.integration.test.mjs
+++ b/backend/test/integration/reports.integration.test.mjs
@@ -177,6 +177,7 @@ test('POST /api/v1/reports/found creates a report with photo upload', async () =
   const response = await request(app)
     .post('/api/v1/reports/found')
     .field('title', 'Found wallet')
+    .field('category', 'Wallets & Purses')
     .field('foundLocation', 'Gym')
     .field('contactEmail', 'finder@example.com')
     .attach('photo', jpegBuffer, {
@@ -190,6 +191,7 @@ test('POST /api/v1/reports/found creates a report with photo upload', async () =
   assert.equal(savedReports.length, 1);
   assert.equal(savedReports[0].data.kind, 'FOUND');
   assert.equal(savedReports[0].data.title, 'Found wallet');
+  assert.equal(savedReports[0].data.category, 'Wallets & Purses');
   assert.equal(savedReports[0].data.status, 'PENDING_VALIDATION');
   assert.equal(uploads.length, 1);
 });

--- a/frontend/src/app/features/public-reporting/found-report-form/found-report-form.component.html
+++ b/frontend/src/app/features/public-reporting/found-report-form/found-report-form.component.html
@@ -62,6 +62,19 @@
                 />
               </app-form-field>
 
+              <app-form-field id="category" label="Category" [required]="true" [error]="getFieldError('category')">
+                <app-select
+                  id="category"
+                  formControlName="category"
+                  placeholder="Select a category"
+                  [invalid]="isFieldInvalid('category')"
+                >
+                  @for (category of categories; track category) {
+                    <option [value]="category">{{ category }}</option>
+                  }
+                </app-select>
+              </app-form-field>
+
               <app-form-field id="description" label="Description" [required]="true" [error]="getFieldError('description')">
                 <app-textarea
                   id="description"

--- a/frontend/src/app/features/public-reporting/found-report-form/found-report-form.component.spec.ts
+++ b/frontend/src/app/features/public-reporting/found-report-form/found-report-form.component.spec.ts
@@ -41,6 +41,7 @@ describe('FoundReportFormComponent', () => {
 
     component.foundForm.patchValue({
       title: 'Found wallet',
+      category: 'Wallets & Purses',
       description: 'Brown leather wallet with documents',
       foundLocation: 'Library',
       foundDate: '2026-02-20',
@@ -56,6 +57,7 @@ describe('FoundReportFormComponent', () => {
     const payload = createFoundReportMock.mock.calls[0][0] as FormData;
 
     expect(payload.get('title')).toBe('Found wallet');
+    expect(payload.get('category')).toBe('Wallets & Purses');
     expect(payload.get('foundLocation')).toBe('Library');
     expect(payload.get('description')).toBe('Brown leather wallet with documents');
     expect(payload.get('contactEmail')).toBe('finder@example.com');

--- a/frontend/src/app/features/public-reporting/found-report-form/found-report-form.component.ts
+++ b/frontend/src/app/features/public-reporting/found-report-form/found-report-form.component.ts
@@ -14,6 +14,7 @@ import { AlertComponent } from '../../../shared/components/feedback/alert.compon
 import { FormFieldComponent } from '../../../shared/components/forms/form-field.component';
 import { InputComponent } from '../../../shared/components/forms/input.component';
 import { PhotoUploadFieldComponent } from '../../../shared/components/forms/photo-upload-field.component';
+import { SelectComponent } from '../../../shared/components/forms/select.component';
 import { TextareaComponent } from '../../../shared/components/forms/textarea.component';
 import { CardComponent } from '../../../shared/components/layout/card.component';
 import { ReportStepsComponent } from '../../../shared/components/navigation/report-steps.component';
@@ -29,6 +30,7 @@ import { mergeSelectedPhotos } from '../../../shared/utils/photo-upload.util';
     FormFieldComponent,
     InputComponent,
     PhotoUploadFieldComponent,
+    SelectComponent,
     TextareaComponent,
     ReportStepsComponent,
     ButtonComponent,
@@ -46,11 +48,15 @@ export class FoundReportFormComponent implements OnInit, OnDestroy {
   currentStep = 1;
   readonly totalSteps = 3;
   readonly todayDate = this.formatLocalDate(new Date());
+  readonly categories = [
+    'Electronics', 'Wallets & Purses', 'Keys', 'ID Cards', 'Clothing',
+    'Backpacks & Bags', 'Books', 'Jewelry', 'Eyewear', 'Personal Items', 'Other'
+  ];
 
   private readonly platformId = inject(PLATFORM_ID);
   private destroy$ = new Subject<void>();
   private readonly stepFields: Record<number, string[]> = {
-    1: ['title', 'description'],
+    1: ['title', 'category', 'description'],
     2: ['foundLocation', 'foundDate', 'foundTime', 'photos'],
     3: ['contactEmail']
   };
@@ -67,6 +73,7 @@ export class FoundReportFormComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.foundForm = this.fb.group({
       title: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(100)]],
+      category: ['', Validators.required],
       description: ['', [Validators.required, Validators.minLength(10), Validators.maxLength(500)]],
       foundLocation: ['', [Validators.required, Validators.maxLength(120)]],
       foundDate: [this.todayDate, [Validators.required, this.validationService.pastDateValidator()]],
@@ -157,6 +164,7 @@ export class FoundReportFormComponent implements OnInit, OnDestroy {
 
     const formData = new FormData();
     formData.append('title', value.title ?? '');
+    formData.append('category', value.category ?? '');
     formData.append('foundLocation', value.foundLocation ?? '');
     // Backend currently accepts a single file field named "photo".
     formData.append('photo', photos[0]);

--- a/frontend/src/app/models/dtos/create-found-report.request.dto.ts
+++ b/frontend/src/app/models/dtos/create-found-report.request.dto.ts
@@ -1,5 +1,6 @@
 export type CreateFoundReportRequest = {
   title: string;
+  category?: string;
   description?: string;
   foundLocation: string;
   foundAt?: string;


### PR DESCRIPTION
## Summary
This PR adds the missing `category` field to the public found-item report form so it matches the lost-item report flow.

## Changes
- added a required category select field to the `Report Found` basic information step
- updated the found report form state and step validation to include `category`
- included `category` in the multipart payload sent to `/reports/found`
- updated the frontend DTO for found report requests
- expanded backend integration coverage to verify that found report `category` is persisted correctly

## Validation
- `npm run lint` in `frontend`
- `npm run build` in `backend`
- `node --test test/integration/reports.integration.test.mjs` in `backend`

## Notes
- backend support for `category` on found reports already existed; this PR completes the frontend flow and verifies persistence
