### PR TITLE
fix: show pending found reports in admin dashboard

### DIFF
--- a/frontend/src/app/features/admin/sections/admin-reports.component.html
+++ b/frontend/src/app/features/admin/sections/admin-reports.component.html
@@ -1,5 +1,4 @@
 <div>
-  <!-- Stats -->
   <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
     <div class="bg-white rounded-xl border border-border/60 p-4 shadow-sm">
       <p class="text-xs text-text-secondary font-medium mb-1">Total Reports</p>
@@ -19,33 +18,29 @@
     </div>
   </div>
 
-  <!-- Toolbar -->
   <div class="bg-white rounded-xl border border-border/60 shadow-sm p-4 mb-5">
     <div class="flex flex-wrap gap-3 items-center">
       <div class="relative flex-1 min-w-[200px]">
         <svg class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary" style="width:15px;height:15px;" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 115 11a6 6 0 0112 0z"/></svg>
-        <input type="text" [(ngModel)]="searchTerm" (ngModelChange)="applyFilters()" placeholder="Search reports…" class="w-full rounded-lg border border-border pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/25 focus:border-primary transition" />
+        <input type="text" [(ngModel)]="searchTerm" (ngModelChange)="applyFilters()" placeholder="Search reports..." class="w-full rounded-lg border border-border pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/25 focus:border-primary transition" />
       </div>
       <select [(ngModel)]="statusFilter" (ngModelChange)="applyFilters()" class="rounded-lg border border-border px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary/25 focus:border-primary transition">
         <option value="all">All statuses</option>
-        <option value="pending">Pending</option>
-        <option value="approved">Validated</option>
-        <option value="rejected">Rejected</option>
+        <option value="pending_validation">Pending</option>
+        <option value="validated">Validated</option>
         <option value="claimed">Claimed</option>
       </select>
       <span class="text-xs text-text-secondary ml-auto">{{ filteredItems.length }} result{{ filteredItems.length === 1 ? '' : 's' }}</span>
     </div>
   </div>
 
-  <!-- Loading -->
   @if (loading()) {
     <div class="bg-white rounded-xl border border-border/60 p-10 text-center shadow-sm">
       <svg class="h-8 w-8 animate-spin text-primary mx-auto mb-3" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" class="opacity-25" stroke="currentColor" stroke-width="3"/><path class="opacity-90" fill="currentColor" d="M12 3a9 9 0 0 1 9 9h-3a6 6 0 0 0-6-6V3Z"/></svg>
-      <p class="text-text-secondary text-sm mb-0">Loading reports…</p>
+      <p class="text-text-secondary text-sm mb-0">Loading reports...</p>
     </div>
   }
 
-  <!-- Error -->
   @if (error()) {
     <div class="rounded-xl border border-error/30 bg-white p-4 text-sm text-error flex items-center gap-2 shadow-sm mb-4">
       <svg style="width:16px;height:16px;flex-shrink:0;" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
@@ -53,14 +48,12 @@
     </div>
   }
 
-  <!-- Empty -->
   @if (!loading() && !error() && filteredItems.length === 0) {
     <div class="bg-white rounded-xl border border-border/60 p-10 text-center shadow-sm">
       <p class="text-text-secondary text-sm mb-0">No reports match the current filters.</p>
     </div>
   }
 
-  <!-- Table -->
   @if (!loading() && !error() && filteredItems.length > 0) {
     <div class="bg-white rounded-xl border border-border/60 shadow-sm overflow-hidden">
       <div class="overflow-x-auto">
@@ -78,22 +71,19 @@
             @for (item of filteredItems; track trackById($index, item)) {
               <tr class="border-b border-border/40 hover:bg-neutral-base/50 transition-colors">
                 <td class="px-4 py-3">
-                  <p class="font-semibold text-text-primary mb-0.5">{{ item.title || item.itemName || 'Untitled' }}</p>
-                  <p class="text-xs text-text-secondary mb-0 line-clamp-1">{{ item.description || '—' }}</p>
+                  <p class="font-semibold text-text-primary mb-0.5">{{ item.title || 'Untitled' }}</p>
+                  <p class="text-xs text-text-secondary mb-0 line-clamp-1">{{ item.referenceCode }}</p>
                 </td>
-                <td class="px-4 py-3 text-text-secondary">{{ item.location || item.locationFound || '—' }}</td>
-                <td class="px-4 py-3 text-text-secondary whitespace-nowrap">{{ item.dateFound || '—' }}</td>
+                <td class="px-4 py-3 text-text-secondary">{{ item.location || '—' }}</td>
+                <td class="px-4 py-3 text-text-secondary whitespace-nowrap">{{ item.dateReported | date:'mediumDate' }}</td>
                 <td class="px-4 py-3">
                   <span class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide" [class]="statusClass(item.status)">
                     {{ item.status || 'unknown' }}
                   </span>
                 </td>
                 <td class="px-4 py-3">
-                  @if (item.status === 'pending') {
-                    <div class="flex gap-2">
-                      <button (click)="approve(item._id)" class="rounded-lg bg-success/10 border border-success/30 px-3 py-1.5 text-xs font-semibold text-success hover:bg-success/20 transition-colors">Validate</button>
-                      <button (click)="reject(item._id)" class="rounded-lg bg-error/10 border border-error/30 px-3 py-1.5 text-xs font-semibold text-error hover:bg-error/20 transition-colors">Reject</button>
-                    </div>
+                  @if (item.status === 'PENDING_VALIDATION') {
+                    <button (click)="approve(item.id)" class="rounded-lg bg-success/10 border border-success/30 px-3 py-1.5 text-xs font-semibold text-success hover:bg-success/20 transition-colors">Validate</button>
                   } @else {
                     <span class="text-xs text-text-secondary">—</span>
                   }

--- a/frontend/src/app/features/admin/sections/admin-reports.component.ts
+++ b/frontend/src/app/features/admin/sections/admin-reports.component.ts
@@ -1,21 +1,24 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { Component, Inject, OnInit, PLATFORM_ID, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Component, Inject, OnInit, PLATFORM_ID, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-type FoundItem = {
-  _id: string;
-  title?: string;
-  itemName?: string;
+type FoundReport = {
+  id: string;
+  kind: 'FOUND' | 'LOST';
+  title: string;
   description?: string;
   category?: string;
   location?: string;
-  locationFound?: string;
-  dateFound?: string;
-  status?: string;
+  dateReported: string;
+  status: string;
+  referenceCode: string;
 };
 
-type ItemsResponse = { items: FoundItem[]; total: number };
+type AdminReportsResponse = {
+  reports: FoundReport[];
+  total: number;
+};
 
 @Component({
   selector: 'app-admin-reports',
@@ -26,70 +29,81 @@ type ItemsResponse = { items: FoundItem[]; total: number };
 export class AdminReportsComponent implements OnInit {
   readonly loading = signal(true);
   readonly error = signal('');
-  allItems: FoundItem[] = [];
-  filteredItems: FoundItem[] = [];
+  allItems: FoundReport[] = [];
+  filteredItems: FoundReport[] = [];
   searchTerm = '';
   statusFilter = 'all';
+
+  constructor(
+    private readonly http: HttpClient,
+    @Inject(PLATFORM_ID) private readonly platformId: object,
+  ) {}
 
   get stats() {
     return {
       total: this.allItems.length,
-      pending: this.allItems.filter(i => i.status === 'pending').length,
-      validated: this.allItems.filter(i => i.status === 'approved' || i.status === 'validated').length,
-      rejected: this.allItems.filter(i => i.status === 'rejected').length,
+      pending: this.allItems.filter((item) => item.status === 'PENDING_VALIDATION').length,
+      validated: this.allItems.filter((item) => item.status === 'VALIDATED').length,
+      rejected: this.allItems.filter((item) => item.status === 'REJECTED').length,
     };
   }
 
-  constructor(private http: HttpClient, @Inject(PLATFORM_ID) private platformId: Object) {}
-
   ngOnInit(): void {
-    if (isPlatformBrowser(this.platformId)) this.load();
-    else this.loading.set(false);
+    if (isPlatformBrowser(this.platformId)) {
+      this.load();
+      return;
+    }
+
+    this.loading.set(false);
   }
 
   load(): void {
     this.loading.set(true);
     this.error.set('');
-    this.http.get<ItemsResponse>('/items?page=1&limit=100').subscribe({
+    this.http.get<AdminReportsResponse>('/admin/reports?kind=FOUND&page=1&limit=100').subscribe({
       next: (res) => {
-        this.allItems = (res.items ?? []).map(i => ({ ...i, status: (i.status || 'pending').toLowerCase() }));
+        this.allItems = res.reports ?? [];
         this.applyFilters();
         this.loading.set(false);
       },
-      error: () => { this.error.set('Failed to load reports.'); this.loading.set(false); }
+      error: () => {
+        this.error.set('Failed to load reports.');
+        this.loading.set(false);
+      },
     });
   }
 
   applyFilters(): void {
     const kw = this.searchTerm.trim().toLowerCase();
-    this.filteredItems = this.allItems.filter(i => {
-      const name = (i.title || i.itemName || '').toLowerCase();
-      const loc = (i.location || i.locationFound || '').toLowerCase();
-      const status = (i.status || '').toLowerCase();
-      const kwMatch = !kw || name.includes(kw) || loc.includes(kw) || status.includes(kw);
+    this.filteredItems = this.allItems.filter((item) => {
+      const name = item.title.toLowerCase();
+      const loc = (item.location || '').toLowerCase();
+      const status = item.status.toLowerCase();
+      const referenceCode = item.referenceCode.toLowerCase();
+      const kwMatch = !kw || name.includes(kw) || loc.includes(kw) || status.includes(kw) || referenceCode.includes(kw);
       const statusMatch = this.statusFilter === 'all' || status === this.statusFilter;
       return kwMatch && statusMatch;
     });
   }
 
   approve(id: string): void {
-    this.http.patch(`/items/${id}/validate`, { status: 'approved' }).subscribe({ next: () => this.load(), error: () => this.error.set('Failed to approve.') });
-  }
-
-  reject(id: string): void {
-    this.http.patch(`/items/${id}/validate`, { status: 'rejected' }).subscribe({ next: () => this.load(), error: () => this.error.set('Failed to reject.') });
+    this.http.patch(`/reports/found/${id}/validate`, {}).subscribe({
+      next: () => this.load(),
+      error: () => this.error.set('Failed to validate found report.'),
+    });
   }
 
   statusClass(status?: string): string {
     const map: Record<string, string> = {
-      pending: 'bg-warning/15 text-warning border-warning/30',
-      approved: 'bg-success/10 text-success border-success/30',
-      validated: 'bg-success/10 text-success border-success/30',
-      rejected: 'bg-error/10 text-error border-error/30',
-      claimed: 'bg-info/10 text-info border-info/30',
+      PENDING_VALIDATION: 'bg-warning/15 text-warning border-warning/30',
+      VALIDATED: 'bg-success/10 text-success border-success/30',
+      REJECTED: 'bg-error/10 text-error border-error/30',
+      CLAIMED: 'bg-info/10 text-info border-info/30',
     };
     return map[status ?? ''] ?? 'bg-border/20 text-text-secondary border-border';
   }
 
-  trackById(_: number, item: FoundItem): string { return item._id; }
+  trackById(_: number, item: FoundReport): string {
+    return item.id;
+  }
 }


### PR DESCRIPTION
## Summary
This PR fixes the admin Found Reports dashboard so newly submitted found-item reports appear in the admin panel before validation.

## Problem
Newly created found reports were being saved correctly in Firestore with status `PENDING_VALIDATION`, but they did not appear:
- in the admin Found Reports panel
- in the public Found Items page

The public page behavior was actually correct, because it only shows validated items.

The real bug was in the admin dashboard: it was loading data from `/items`, which only returns public validated items, instead of loading from the admin reports endpoint.

## Changes
- updated the admin Found Reports section to load data from `/admin/reports?kind=FOUND`
- made the admin table display pending found reports from the `reports` collection
- updated the status filtering to work with backend report statuses like `PENDING_VALIDATION` and `VALIDATED`
- changed the admin validate action to call the real found report validation endpoint: `/reports/found/:id/validate`
- adjusted the table to display report reference codes and report dates from the admin reports payload

## Expected Behavior
- when a user submits a found report, it appears in the admin dashboard as `PENDING_VALIDATION`
- after the admin validates it, the report becomes `VALIDATED`
- only then does it appear on the public `/found-items` page

## Validation
- confirmed local branch was aligned with `dev` before the change
- ran `npm run lint` in `frontend`

## Notes
- this PR does not include unrelated local changes in `public-env.generated.ts`
