### PR TITLE
fix: refresh claim request success state

### DIFF
--- a/frontend/src/app/features/claims/pages/claim-request/claim-request.ts
+++ b/frontend/src/app/features/claims/pages/claim-request/claim-request.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { finalize } from 'rxjs';
@@ -59,6 +59,7 @@ export class ClaimRequest implements OnInit {
     private readonly router: Router,
     private readonly claimsApi: ClaimsApiService,
     private readonly authService: AuthService,
+    private readonly cdr: ChangeDetectorRef,
   ) {}
 
   ngOnInit(): void {
@@ -68,6 +69,7 @@ export class ClaimRequest implements OnInit {
         email: session.user.email,
         fullName: session.user.displayName ?? '',
       });
+      this.cdr.detectChanges();
     }
   }
 
@@ -123,14 +125,19 @@ export class ClaimRequest implements OnInit {
       claimantEmail: v.email ?? '',
       phone: v.phone?.trim() || undefined,
     })
-      .pipe(finalize(() => { this.isSubmitting = false; }))
+      .pipe(finalize(() => {
+        this.isSubmitting = false;
+        this.cdr.detectChanges();
+      }))
       .subscribe({
         next: (result) => {
           this.claimResult = result;
           this.submitSuccess = true;
+          this.cdr.detectChanges();
         },
         error: (err: ErrorResponse) => {
           this.submitError = this.mapClaimError(err);
+          this.cdr.detectChanges();
         },
       });
   }
@@ -155,5 +162,6 @@ export class ClaimRequest implements OnInit {
     this.claimResult = null;
     this.currentStep = 1;
     this.ngOnInit();
+    this.cdr.detectChanges();
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes the Claim Request page so the success state appears immediately after submitting a claim.

## Problem
After clicking `Submit Claim`, the request was being processed successfully, but the page stayed stuck in the loading state.  
The confirmation screen only appeared after another UI interaction, such as clicking the `Claim Request` navigation item again.

## Root Cause
The component state was being updated after the async request finished, but the view was not always refreshing immediately in the current frontend setup.

## Changes
- updated the Claim Request component to trigger view refresh after async submit completion
- ensured the UI updates correctly on:
  - successful claim submission
  - failed submission
  - submit finalization
  - form reset / session prefill

## Result
- the loading button no longer appears stuck after submitting
- the success confirmation screen appears immediately when the claim is created
- error feedback also updates immediately without requiring another click

## Validation
- `npm run lint` in `frontend`

## Notes
- this PR only includes the Claim Request UI refresh fix
- unrelated local changes in `public-env.generated.ts` were intentionally left out
