### PR TITLE
feat: add branded not found page

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -10,6 +10,7 @@ import { EditReportPageComponent } from './features/public-reporting/edit-report
 import { LoginComponent } from './features/auth/login/login.component';
 import { RegisterComponent } from './features/auth/register/register.component';
 import { AdminDashboardComponent } from './features/admin/admin-dashboard.component';
+import { NotFoundPageComponent } from './features/not-found/not-found-page.component';
 import { adminAuthGuard } from './core/guards/admin-auth.guard';
 import { authenticatedUserGuard } from './core/guards/student-auth.guard';
 
@@ -96,6 +97,7 @@ export const routes: Routes = [
   // optional fallback
   {
     path: '**',
-    redirectTo: ''
+    component: NotFoundPageComponent,
+    title: 'Page Not Found - FalconFind'
   }
 ];

--- a/frontend/src/app/features/not-found/not-found-page.component.ts
+++ b/frontend/src/app/features/not-found/not-found-page.component.ts
@@ -1,0 +1,65 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-not-found-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  template: `
+    <section class="relative overflow-hidden bg-white">
+      <div class="pointer-events-none absolute inset-0">
+        <div class="absolute left-1/2 top-20 h-56 w-56 -translate-x-1/2 rounded-full bg-primary/8 blur-3xl"></div>
+        <div class="absolute bottom-10 left-10 h-40 w-40 rounded-full bg-soft-accent/30 blur-3xl"></div>
+      </div>
+
+      <div class="relative mx-auto flex min-h-[calc(100vh-72px)] max-w-5xl items-center justify-center px-4 py-16 sm:px-6 lg:px-8">
+        <div class="w-full text-center">
+          <div class="mx-auto flex w-fit items-end gap-1 sm:gap-3">
+            <span class="text-[88px] font-bold leading-none tracking-[-0.08em] text-primary sm:text-[160px]">4</span>
+            <span class="flex h-20 w-20 items-center justify-center sm:h-32 sm:w-32">
+              <img
+                src="/SVG/Icon1.svg"
+                alt="FalconFind icon"
+                class="h-16 w-auto sm:h-24"
+              />
+            </span>
+            <span class="text-[88px] font-bold leading-none tracking-[-0.08em] text-primary sm:text-[160px]">4</span>
+            <span class="mb-2 ml-2 text-2xl font-semibold uppercase tracking-tight text-text-primary sm:mb-4 sm:ml-4 sm:text-5xl">
+              Error
+            </span>
+          </div>
+
+          <div class="mt-8">
+            <img
+              src="/PNG/LogoPrincipal.png"
+              alt="FalconFind"
+              class="mx-auto h-9 w-auto sm:h-11"
+            />
+          </div>
+
+          <div class="mx-auto mt-10 flex max-w-2xl flex-col items-center text-center">
+            <h1 class="text-5xl font-bold uppercase leading-none tracking-[-0.05em] text-text-primary sm:text-8xl">
+              OH NO!
+            </h1>
+            <p class="mt-3 text-2xl font-medium text-primary sm:text-4xl">
+              But that's okay.
+            </p>
+
+            <p class="mt-8 max-w-xl text-base leading-8 text-text-secondary sm:text-xl">
+              Even good detectives take a wrong turn sometimes. This page is missing, but your way back is not.
+            </p>
+
+            <a
+              routerLink="/"
+              class="mt-12 inline-flex items-center justify-center rounded-none bg-primary px-10 py-4 text-lg font-semibold !text-white shadow-sm transition-colors hover:bg-secondary sm:px-16"
+            >
+              Back to home
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  `,
+})
+export class NotFoundPageComponent {}


### PR DESCRIPTION
## Summary
This PR adds a branded 404 page to FalconFind and replaces the previous fallback redirect to the home page.

## Problem
When a user entered an invalid URL, the app silently redirected them to `/`, which made the experience confusing and did not clearly explain what happened.

## Changes
- added a dedicated `Page Not Found` screen for unknown routes
- updated the Angular wildcard route to render the new 404 page instead of redirecting to home
- designed the page to match the FalconFind visual identity
- used the FalconFind icon as the `0` in the `404` composition
- kept the layout intentionally simple with:
  - a clear error message
  - a short friendly line
  - a single `Back to home` CTA

## Result
- users now see a proper 404 page when they access an invalid route
- the experience feels more professional and consistent with the rest of the site
- users still have a clear path back to the main flow through the home button

## Validation
- `npm run lint` in `frontend`

## Notes
- unrelated local changes in `public-env.generated.ts` were intentionally not included in this PR
